### PR TITLE
Feature Update Psn ID

### DIFF
--- a/cogs/account_set_psn.py
+++ b/cogs/account_set_psn.py
@@ -11,7 +11,8 @@ from data.connector import CONN
 from data import UserBuilder, DiscordBuilder
 from core.exceptions import (
     CoroutineFailed,
-    DiscordNotRegistered
+    DiscordNotRegistered,
+    PsnIDAlreadyRegistered
 )
 from core import BaseCog
 
@@ -50,6 +51,18 @@ class SetPsn(BaseCog):
                         "No account registered for this discord user."
                     )
 
+                user = await self.user_builder.select_user_psn(
+                    session,
+                    psn_name
+                )
+                if user:
+                    print(user)
+                    print(user.id)
+                    if not user.id == discord_user.user_id:
+                        raise PsnIDAlreadyRegistered(
+                            "Psn ID already registered. Please use different Psn ID."
+                        )
+
                 if not await self.user_builder.update_user_psn(
                     session,
                     discord_user.user_id,
@@ -72,7 +85,8 @@ class SetPsn(BaseCog):
                 await session.commit()
 
             except (
-                DiscordNotRegistered
+                DiscordNotRegistered,
+                PsnIDAlreadyRegistered
             ) as e:
                 logging.warning("%s: %s", interaction.user.id, e)
                 await interaction.response.send_message(

--- a/core/exceptions.py
+++ b/core/exceptions.py
@@ -37,6 +37,9 @@ class UsernameAlreadyRegistered(Exception):
 class UsernameIncorrect(Exception):
     """Username is already registered in database."""
 
+class PsnIDAlreadyRegistered(Exception):
+    """Psn ID is already reegistered to a different user."""
+
 class RestrictedUsername(Exception):
     """Username is restricted or contains inappropriate words."""
 

--- a/data/querybuilder/users.py
+++ b/data/querybuilder/users.py
@@ -48,7 +48,7 @@ class UserBuilder():
         stmt = select(Users).options(
             load_only(Users.id, Users.psn_id)
         ).where(Users.psn_id == psn_id)
-        rows = await self.db.select_objects(session, stmt)
+        rows = await self.db.select_object(session, stmt)
         return rows
 
     async def update_user_psn(

--- a/data/querybuilder/users.py
+++ b/data/querybuilder/users.py
@@ -43,6 +43,14 @@ class UserBuilder():
         )
         return await self.db.update_objects(session, stmt)
 
+    async def select_user_psn(self, session, psn_id: str):
+        """Select user psn_id."""
+        stmt = select(Users).options(
+            load_only(Users.id, Users.psn_id)
+        ).where(Users.psn_id == psn_id)
+        rows = await self.db.select_objects(session, stmt)
+        return rows
+
     async def update_user_psn(
         self,
         session,


### PR DESCRIPTION
Added command account_set_psn <psn_id> to allow users updating their psn binding. Checks if psn id is already taken.